### PR TITLE
Fix dynamic log path in Move script

### DIFF
--- a/MALA-Deploy.ps1
+++ b/MALA-Deploy.ps1
@@ -1,4 +1,4 @@
-﻿# Script 3: Run OfficeC2RLogCollector if logs don't exist
+# Script 3: Run OfficeC2RLogCollector if logs don't exist
 
 $malaPath = "C:\mala"
 $exePath = Join-Path $malaPath "OfficeC2RLogCollector.exe"

--- a/MALA-Detect.ps1
+++ b/MALA-Detect.ps1
@@ -1,4 +1,4 @@
-﻿# Script 2: Check if logs exist in C:\mala\C2RLogs
+# Script 2: Check if logs exist in C:\mala\C2RLogs
 
 $c2rLogsPath = "C:\mala\C2RLogs"
 $username = $env:USERNAME

--- a/MALA-Download.ps1
+++ b/MALA-Download.ps1
@@ -1,4 +1,4 @@
-﻿# Script 1: Download the log collector and place it in C:\mala
+# Script 1: Download the log collector and place it in C:\mala
 
 # Define variables
 $downloadUrl = "https://download.microsoft.com/download/2/d/9/2d9f7837-c440-42ca-86f8-9d46cd332c8c/officedeploymentlogcollector.exe"

--- a/MALA-Move-README.md
+++ b/MALA-Move-README.md
@@ -15,12 +15,11 @@ The script checks for the existence of the `C2RLogs` folder in the user's temp d
 ## 🧾 Script Breakdown
 
 ```powershell
-$tempLogPath = "C:\Users\mattp\AppData\Local\Temp\C2RLogs"
+$tempLogPath = Join-Path $env:USERPROFILE "AppData\Local\Temp\C2RLogs"
 $destinationPath = "C:\mala"
 ```
 
-* Defines the source and target directories.
-* Customize the username (`mattp`) as needed based on the machine.
+* Defines the source and target directories using the current user's profile.
 
 ---
 
@@ -73,8 +72,7 @@ if (Test-Path $tempLogPath) {
 ## ▶️ How to Use the Script
 
 1. **Open PowerShell as Administrator**
-2. **Modify the script** if necessary to match your username in the path.
-3. **Run the script** by pasting it into PowerShell or saving it as a `.ps1` file:
+2. **Run the script** by pasting it into PowerShell or saving it as a `.ps1` file:
 
    ```powershell
    .\MoveC2RLogs.ps1

--- a/MALA-Move.ps1
+++ b/MALA-Move.ps1
@@ -1,6 +1,6 @@
-﻿# Script 4: Move C2RLogs from temp to C:\mala
+# Script 4: Move C2RLogs from temp to C:\mala
 
-$tempLogPath = "C:\Users\mattp\AppData\Local\Temp\C2RLogs"
+$tempLogPath = Join-Path $env:USERPROFILE "AppData\Local\Temp\C2RLogs"
 $destinationPath = "C:\mala"
 
 if (Test-Path $tempLogPath) {


### PR DESCRIPTION
## Summary
- remove BOM markers from PowerShell scripts
- make `MALA-Move.ps1` use the current user's profile
- update documentation to match the new dynamic path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68489aabfc808332a310c78489b0c623